### PR TITLE
Fix for #39 - Building docs fails with AttributeError: 'NoneType' object has no attribute 'replace' 

### DIFF
--- a/mkdocs_puml/plugin.py
+++ b/mkdocs_puml/plugin.py
@@ -137,7 +137,7 @@ class PlantUMLPlugin(BasePlugin):
             # MkDocs >=1.4 doesn't have html attribute.
             # This is required for integration with mkdocs-print-page plugin.
             # TODO: Remove the support of older versions in future releases
-            if hasattr(page, 'html'):
+            if hasattr(page, 'html') and page.html is not None:
                 page.html = self._replace(v, page.html)
 
         return output


### PR DESCRIPTION
This fixes issue https://github.com/MikhailKravets/mkdocs_puml/issues/39