### PR TITLE
feat: support dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Jon -> Sansa : hello
 @enduml
 """
 
-puml = PlantUML(puml_url, num_worker=2)
+puml = PlantUML(puml_url, num_workers=2)
 svg_for_diag1, svg_for_diag2 = puml.translate([diagram1, diagram2])
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,16 +37,19 @@ plugins:
         num_workers: 8
         puml_keyword: puml
         verify_ssl: true
+        auto_dark: false
 ```
 
 Where
 
-| Parmeter | Type                 | Descripton                                                     |
-|----------|----------------------|----------------------------------------------------------------|
-| `puml_url` | `str`. Required      | URL to the plantuml service                                    |
-| `num_workers` | `int`. Default `8`   | Max amount of concurrent workers that request plantuml service |
-| `puml_keyword` | `str`. Default `puml` | The keyword for PlantUML code fence, i.e. \```puml \```        |
-| `verify_ssl` | `bool`. Default `True` | Designates whether `requests` should verify SSL or not |
+| Parameter      | Type                   | Description                                                                 |
+|----------------|------------------------|-----------------------------------------------------------------------------|
+| `puml_url`     | `str`. Required        | URL to the PlantUML service                                                 |
+| `num_workers`  | `int`. Default `8`     | Max amount of concurrent workers that request the PlantUML service          |
+| `puml_keyword` | `str`. Default `puml`  | The keyword for PlantUML code fence, i.e. \```puml \```                     |
+| `verify_ssl`   | `bool`. Default `True` | Designates whether `requests` should verify SSL or not                      |
+| `auto_dark`    | `bool`. Default `False`| Designates whether the plugin should also generate dark mode images         |
+
 
 Now, you can put your puml diagrams into your `.md` documentation. For example,
 
@@ -62,6 +65,16 @@ Bob -> Alice : hello
 
 At the build step `mkdocs` sends requests to `puml_url` and substitutes your
 diagram with the `svg` images from the responses.
+
+### Dark Mode Support
+
+The module supports dark mode, this can be enabled with the `auto_dark` option.
+
+When this option is set the module will generate a second copy of the diagram in dark mode using the `/dsvg` server option.
+
+In order to dynamically switch the image choice the module include a javascript file [dark.js](mkdocs_puml/static/dark.js).
+
+> **Tip:** Try it with the `skinparam backgroundColor transparent` directive in your puml to see if it looks better :)
 
 ### Run PlantUML service with Docker
 

--- a/mkdocs_puml/encoder.py
+++ b/mkdocs_puml/encoder.py
@@ -2,15 +2,12 @@ import base64
 import string
 from zlib import compress
 
-__all__ = ('encode',)
+__all__ = ("encode",)
 
 _B64_CHARS = f"{string.ascii_uppercase}{string.ascii_lowercase}{string.digits}+/"
 _PUML_CHARS = f"{string.digits}{string.ascii_uppercase}{string.ascii_lowercase}-_"
 
-_TRANSLATE_MAP = bytes.maketrans(
-    _B64_CHARS.encode('utf-8'),
-    _PUML_CHARS.encode('utf-8')
-)
+_TRANSLATE_MAP = bytes.maketrans(_B64_CHARS.encode("utf-8"), _PUML_CHARS.encode("utf-8"))
 
 
 def encode(content: str) -> str:
@@ -27,7 +24,7 @@ def encode(content: str) -> str:
         Encoded string that can be used in plantUML service
         to build diagram images
     """
-    content = compress(content.encode('utf-8'))[2:-4]  # 0:2 - header, -4: - checksum
+    content = compress(content.encode("utf-8"))[2:-4]  # 0:2 - header, -4: - checksum
     content = base64.b64encode(content)
     content = content.translate(_TRANSLATE_MAP)
-    return content.decode('utf-8')
+    return content.decode("utf-8")

--- a/mkdocs_puml/plugin.py
+++ b/mkdocs_puml/plugin.py
@@ -36,20 +36,23 @@ class PlantUMLPlugin(BasePlugin):
         verify_ssl (bool): Designates whether the ``requests`` should verify SSL certiticate
         auto_dark (bool): Designates whether the plugin should automatically generate dark mode images.
     """
+
     div_class_name = "puml"
     pre_class_name = "diagram-uuid"
 
     config_scheme = (
-        ('puml_url', Type(str, required=True)),
-        ('num_workers', Type(int, default=8)),
-        ('puml_keyword', Type(str, default='puml')),
-        ('verify_ssl', Type(bool, default=True)),
-        ('auto_dark', Type(bool, default=False))
+        ("puml_url", Type(str, required=True)),
+        ("num_workers", Type(int, default=8)),
+        ("puml_keyword", Type(str, default="puml")),
+        ("verify_ssl", Type(bool, default=True)),
+        ("auto_dark", Type(bool, default=False)),
     )
 
     def __init__(self):
         self.regex: typing.Optional[typing.Any] = None
-        self.uuid_regex = re.compile(rf'<pre class="{self.pre_class_name}">(.+?)</pre>', flags=re.DOTALL)
+        self.uuid_regex = re.compile(
+            rf'<pre class="{self.pre_class_name}">(.+?)</pre>', flags=re.DOTALL
+        )
 
         self.puml: typing.Optional[PlantUML] = None
         self.diagrams = {
@@ -69,20 +72,20 @@ class PlantUMLPlugin(BasePlugin):
             Full config of the mkdocs
         """
         self.puml_light = PlantUML(
-            self.config['puml_url'],
-            num_workers=self.config['num_workers'],
-            verify_ssl=self.config['verify_ssl'],
-            output_format="svg"
+            self.config["puml_url"],
+            num_workers=self.config["num_workers"],
+            verify_ssl=self.config["verify_ssl"],
+            output_format="svg",
         )
         self.puml_dark = PlantUML(
-            self.config['puml_url'],
-            num_workers=self.config['num_workers'],
-            verify_ssl=self.config['verify_ssl'],
-            output_format="dsvg"
+            self.config["puml_url"],
+            num_workers=self.config["num_workers"],
+            verify_ssl=self.config["verify_ssl"],
+            output_format="dsvg",
         )
-        self.puml_keyword = self.config['puml_keyword']
+        self.puml_keyword = self.config["puml_keyword"]
         self.regex = re.compile(rf"```{self.puml_keyword}(\n.+?)```", flags=re.DOTALL)
-        self.auto_dark = self.config['auto_dark']
+        self.auto_dark = self.config["auto_dark"]
         return config
 
     def on_page_markdown(self, markdown: str, *args, **kwargs) -> str:
@@ -106,8 +109,7 @@ class PlantUMLPlugin(BasePlugin):
             id_ = str(uuid.uuid4())
             self.diagrams[id_] = v
             markdown = markdown.replace(
-                f"```{self.puml_keyword}{v}```",
-                f'<pre class="{self.pre_class_name}">{id_}</pre>'
+                f"```{self.puml_keyword}{v}```", f'<pre class="{self.pre_class_name}">{id_}</pre>'
             )
 
         return markdown
@@ -124,7 +126,7 @@ class PlantUMLPlugin(BasePlugin):
             Jinja environment
         """
         diagram_contents = [diagram for diagram, _ in self.diagrams.values()]
-        
+
         if self.auto_dark:
             light_svgs = self.puml_light.translate(diagram_contents)
             dark_svgs = self.puml_dark.translate(diagram_contents)
@@ -156,13 +158,13 @@ class PlantUMLPlugin(BasePlugin):
             # MkDocs >=1.4 doesn't have html attribute.
             # This is required for integration with mkdocs-print-page plugin.
             # TODO: Remove the support of older versions in future releases
-            if hasattr(page, 'html') and page.html is not None:
+            if hasattr(page, "html") and page.html is not None:
                 page.html = self._replace(v, page.html)
-                
+
             # Inject custom JavaScript only if PUML diagrams are present
             script_tag = '<script src="assets/javascripts/puml/dark.js"></script>'
             if script_tag not in output:
-                output = output.replace('</body>', f'{script_tag}</body>')
+                output = output.replace("</body>", f"{script_tag}</body>")
 
         return output
 
@@ -178,10 +180,7 @@ class PlantUMLPlugin(BasePlugin):
             )
         else:
             replacement = f'<div class="{self.div_class_name}">{light_svg}</div>'
-        return content.replace(
-            f'<pre class="{self.pre_class_name}">{key}</pre>',
-            replacement
-        )
+        return content.replace(f'<pre class="{self.pre_class_name}">{key}</pre>', replacement)
 
     def on_post_build(self, config):
         """
@@ -197,9 +196,9 @@ class PlantUMLPlugin(BasePlugin):
 
         """
         # Path to the static directory in the plugin
-        static_dir = os.path.join(os.path.dirname(__file__), 'static')
+        static_dir = os.path.join(os.path.dirname(__file__), "static")
         # Destination directory in the site output
-        dest_dir = os.path.join(config['site_dir'], 'assets/javascripts/puml')
+        dest_dir = os.path.join(config["site_dir"], "assets/javascripts/puml")
 
         if not os.path.exists(dest_dir):
             os.makedirs(dest_dir)

--- a/mkdocs_puml/plugin.py
+++ b/mkdocs_puml/plugin.py
@@ -123,14 +123,16 @@ class PlantUMLPlugin(BasePlugin):
         Returns:
             Jinja environment
         """
+        diagram_contents = [diagram for diagram, _ in self.diagrams.values()]
+        
         if self.auto_dark:
-            light_svgs = self.puml_light.translate(self.diagrams.values())
-            dark_svgs = self.puml_dark.translate(self.diagrams.values())
-            for key, (light_svg, dark_svg) in zip(self.diagrams.keys(), zip(light_svgs, dark_svgs)):
+            light_svgs = self.puml_light.translate(diagram_contents)
+            dark_svgs = self.puml_dark.translate(diagram_contents)
+            for (key, _), light_svg, dark_svg in zip(self.diagrams.items(), light_svgs, dark_svgs):
                 self.diagrams[key] = (light_svg, dark_svg)
         else:
-            svgs = self.puml_light.translate(self.diagrams.values())
-            for key, svg in zip(self.diagrams.keys(), svgs):
+            svgs = self.puml_light.translate(diagram_contents)
+            for (key, _), svg in zip(self.diagrams.items(), svgs):
                 self.diagrams[key] = (svg, None)
         return env
 

--- a/mkdocs_puml/plugin.py
+++ b/mkdocs_puml/plugin.py
@@ -59,7 +59,7 @@ class PlantUMLPlugin(BasePlugin):
     def on_config(self, config: Config) -> Config:
         """Event that is fired by mkdocs when configs are created.
 
-        self.puml instance is populated in this event.
+        self.puml instances are populated in this event.
 
         Args:
             config: Full mkdocs.yml config file. To access configs of PlantUMLPlugin only,
@@ -68,10 +68,17 @@ class PlantUMLPlugin(BasePlugin):
         Returns:
             Full config of the mkdocs
         """
-        self.puml = PlantUML(
+        self.puml_light = PlantUML(
             self.config['puml_url'],
             num_workers=self.config['num_workers'],
             verify_ssl=self.config['verify_ssl'],
+            output_format="svg"
+        )
+        self.puml_dark = PlantUML(
+            self.config['puml_url'],
+            num_workers=self.config['num_workers'],
+            verify_ssl=self.config['verify_ssl'],
+            output_format="dsvg"
         )
         self.puml_keyword = self.config['puml_keyword']
         self.regex = re.compile(rf"```{self.puml_keyword}(\n.+?)```", flags=re.DOTALL)
@@ -117,12 +124,12 @@ class PlantUMLPlugin(BasePlugin):
             Jinja environment
         """
         if self.auto_dark:
-            light_svgs = self.puml.translate(self.diagrams.values())
-            dark_svgs = self.puml.translate(self.diagrams.values(), dark_mode=True)
+            light_svgs = self.puml_light.translate(self.diagrams.values())
+            dark_svgs = self.puml_dark.translate(self.diagrams.values())
             for key, (light_svg, dark_svg) in zip(self.diagrams.keys(), zip(light_svgs, dark_svgs)):
                 self.diagrams[key] = (light_svg, dark_svg)
         else:
-            svgs = self.puml.translate(self.diagrams.values())
+            svgs = self.puml_light.translate(self.diagrams.values())
             for key, svg in zip(self.diagrams.keys(), svgs):
                 self.diagrams[key] = (svg, None)
         return env

--- a/mkdocs_puml/plugin.py
+++ b/mkdocs_puml/plugin.py
@@ -44,7 +44,7 @@ class PlantUMLPlugin(BasePlugin):
         ('num_workers', Type(int, default=8)),
         ('puml_keyword', Type(str, default='puml')),
         ('verify_ssl', Type(bool, default=True)),
-        ('auto_dark', Type(bool, default=True))
+        ('auto_dark', Type(bool, default=False))
     )
 
     def __init__(self):

--- a/mkdocs_puml/puml.py
+++ b/mkdocs_puml/puml.py
@@ -129,4 +129,4 @@ class PlantUML:
             It can be used to add support of light / dark theme.
         """
         svg.setAttribute('preserveAspectRatio', "true")
-        svg.setAttribute('style', 'background: #ffffff')
+        svg.setAttribute('style', 'background: var(--md-default-bg-color)')

--- a/mkdocs_puml/puml.py
+++ b/mkdocs_puml/puml.py
@@ -106,7 +106,6 @@ class PlantUML:
             urljoin(self.base_url, f"{format_path}/{encoded_diagram}"),
             verify=self.verify_ssl
         )
-        return resp.content.decode('utf-8', errors='ignore')
 
         # Use 'ignore' to strip non-utf chars
         return resp.content.decode('utf-8', errors='ignore')

--- a/mkdocs_puml/puml.py
+++ b/mkdocs_puml/puml.py
@@ -26,10 +26,17 @@ class PlantUML:
             puml = PlantUML("https://www.plantuml.com")
             svg = puml.translate([diagram])[0]
     """
+
     _html_comment_regex = re.compile(r"<!--.*?-->", flags=re.DOTALL)
 
-    def __init__(self, base_url: str, num_workers: int = 5, verify_ssl: bool = True, output_format: str = "svg"):
-        self.base_url = base_url if base_url.endswith('/') else f"{base_url}/"
+    def __init__(
+        self,
+        base_url: str,
+        num_workers: int = 5,
+        verify_ssl: bool = True,
+        output_format: str = "svg",
+    ):
+        self.base_url = base_url if base_url.endswith("/") else f"{base_url}/"
         self.base_url = f"{self.base_url}{output_format}/"
 
         if num_workers <= 0:
@@ -100,13 +107,10 @@ class PlantUML:
         Returns:
             SVG representation of the diagram
         """
-        resp = requests.get(
-            urljoin(self.base_url, encoded_diagram),
-            verify=self.verify_ssl
-        )
+        resp = requests.get(urljoin(self.base_url, encoded_diagram), verify=self.verify_ssl)
 
         # Use 'ignore' to strip non-utf chars
-        return resp.content.decode('utf-8', errors='ignore')
+        return resp.content.decode("utf-8", errors="ignore")
 
     def _clean_comments(self, content: str) -> str:
         return self._html_comment_regex.sub("", content)
@@ -116,7 +120,7 @@ class PlantUML:
         for future modifications
         """
         dom = parseString(content)  # nosec
-        svg = dom.getElementsByTagName('svg')[0]
+        svg = dom.getElementsByTagName("svg")[0]
         return svg
 
     def _stylize_svg(self, svg: Element):
@@ -125,5 +129,5 @@ class PlantUML:
         Notes:
             It can be used to add support of light / dark theme.
         """
-        svg.setAttribute('preserveAspectRatio', "true")
-        svg.setAttribute('style', 'background: var(--md-default-bg-color)')
+        svg.setAttribute("preserveAspectRatio", "true")
+        svg.setAttribute("style", "background: var(--md-default-bg-color)")

--- a/mkdocs_puml/static/dark.js
+++ b/mkdocs_puml/static/dark.js
@@ -22,7 +22,7 @@
  */
 
 // Set this flag to true for debugging output, false to suppress logs
-const DEBUG = true;
+const DEBUG = false;
 
 /**
  * Helper function for controlled logging.

--- a/mkdocs_puml/static/dark.js
+++ b/mkdocs_puml/static/dark.js
@@ -1,0 +1,142 @@
+/**
+ * mkdocs-puml plugin - Auto Dark Mode Script
+ * ==========================================
+ *
+ * This script is designed to work with the mkdocs-puml plugin and the
+ * mkdocs-material theme to automatically switch between light and dark themes.
+ *
+ * Dependencies:
+ * -------------
+ * - The script requires the mkdocs-puml plugin to be installed and configured
+ *   in the MkDocs project.
+ * - The script is intended to be used with the mkdocs-material theme.
+ *
+ * Description:
+ * ------------
+ * The script listens for changes in the system preference for dark mode and
+ * updates the theme accordingly. It also listens for changes in the MkDocs
+ * theme preference and updates the theme based on the user's selection.
+ * The script toggles the visibility of PlantUML divs based on the theme to ensure
+ * that the correct image is displayed.
+ *
+ */
+
+// Set this flag to true for debugging output, false to suppress logs
+const DEBUG = true;
+
+/**
+ * Helper function for controlled logging.
+ * @param {string} message - The message to log.
+ */
+function log(message) {
+  if (DEBUG) {
+    console.log(message);
+  }
+}
+
+/**
+ * Retrieves the current theme state based on system preferences.
+ * @returns {string} - The current theme state ('dark' or 'light').
+ */
+function getThemeState() {
+  const systemPreference = window.matchMedia("(prefers-color-scheme: dark)")
+    .matches
+    ? "dark"
+    : "light";
+  log(`🌐 System Preference: ${systemPreference}`);
+  return systemPreference;
+}
+
+/**
+ * Retrieves the current theme state based on the data attribute on the body.
+ * @returns {string} - The current theme state ('dark', 'light', or 'auto').
+ */
+function getMkdocsThemeState() {
+  const colorScheme = document.body.getAttribute("data-md-color-media");
+
+  let themeState;
+  switch (colorScheme) {
+    case "(prefers-color-scheme: dark)":
+      themeState = "dark";
+      break;
+    case "(prefers-color-scheme: light)":
+      themeState = "light";
+      break;
+    case "(prefers-color-scheme)":
+      themeState = "auto";
+      break;
+    default:
+      themeState = getThemeState();
+      break;
+  }
+
+  log(`📋 Mkdocs Preference: ${themeState}`);
+  return themeState;
+}
+
+/**
+ * Updates the theme based on the provided mode.
+ * @param {string} mode - The theme mode ('dark' or 'light').
+ */
+function updateTheme(mode) {
+  log(`🔄 Updating theme`);
+  togglePumlVisibility(mode);
+}
+
+/**
+ * Toggles the visibility of PUML divs based on the theme.
+ * @param {string} mode - The theme mode ('dark' or 'light').
+ */
+function togglePumlVisibility(mode) {
+  const lightDivs = document.querySelectorAll(`[data-puml-theme="light"]`);
+  const darkDivs = document.querySelectorAll(`[data-puml-theme="dark"]`);
+
+  lightDivs.forEach((div) => {
+    div.style.display = mode === "light" ? "block" : "none";
+  });
+
+  darkDivs.forEach((div) => {
+    div.style.display = mode === "dark" ? "block" : "none";
+  });
+
+  log(`🌓 PUML visibility toggled to ${mode} mode.`);
+}
+
+// Main script logic
+document.addEventListener("DOMContentLoaded", () => {
+  // Handle initial theme setup
+  const mkdocsTheme = getMkdocsThemeState();
+  const systemTheme = getThemeState();
+  let currentTheme;
+
+  if (mkdocsTheme === "auto") {
+    currentTheme = systemTheme;
+  } else {
+    currentTheme = mkdocsTheme;
+  }
+
+  updateTheme(currentTheme);
+
+  // Listen for system preference changes if the theme is set to 'auto'
+  const darkModeMediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+  darkModeMediaQuery.addEventListener("change", (e) => {
+    const newTheme = e.matches ? "dark" : "light";
+    log(`⚡ System preference changed to: ${newTheme} mode`);
+    // if not in auto mode, do nothing
+    if (getMkdocsThemeState() === "auto") {
+      updateTheme(newTheme);
+    }
+  });
+
+  // Set up event listeners for the theme toggle inputs
+  document.querySelectorAll('input[name="__palette"]').forEach((input) => {
+    input.addEventListener("change", () => {
+      log(`⚡ Mkdocs preference changed`);
+      let newTheme = getMkdocsThemeState();
+      if (newTheme === "auto") {
+        newTheme = getThemeState();
+      }
+      updateTheme(newTheme);
+    });
+  });
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,7 @@ Home = "https://github.com/MikhailKravets/mkdocs_puml"
 
 [project.entry-points."mkdocs.plugins"]
 plantuml = "mkdocs_puml.plugin:PlantUMLPlugin"
+
+[tool.flit.sdist]
+# Specify the files to include in the source distribution
+include = ["mkdocs_puml/static/custom.js"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import requests
 BASE_PUML_URL = "https://mocked.org/"
 BASE_PUML_KEYWORD = "puml"
 CUSTOM_PUML_KEYWORD = "plantuml"
-TESTDATA_DIR = Path(__file__).resolve().parent.joinpath('testdata')
+TESTDATA_DIR = Path(__file__).resolve().parent.joinpath("testdata")
 
 
 @pytest.fixture(scope="package")
@@ -16,18 +16,21 @@ def diagram_and_encoded():
     """The fixture to return puml diagram and
     the encoded by plantuml.com string
     """
-    return "@startuml\nBob -> Alice : hello\n@enduml", "SoWkIImgAStDuNBAJrBGjLDmpCbCJbMmKiX8pSd9vt98pKi1IW80"
+    return (
+        "@startuml\nBob -> Alice : hello\n@enduml",
+        "SoWkIImgAStDuNBAJrBGjLDmpCbCJbMmKiX8pSd9vt98pKi1IW80",
+    )
 
 
 @pytest.fixture(scope="package")
 def svg_diagram():
-    with open(TESTDATA_DIR.joinpath('plantuml.svg')) as f:
+    with open(TESTDATA_DIR.joinpath("plantuml.svg")) as f:
         return f.read()
 
 
 @pytest.fixture(scope="function")
 def mock_requests(monkeypatch, svg_diagram):
     p = Mock()
-    p.return_value.content = svg_diagram.encode('utf-8')
+    p.return_value.content = svg_diagram.encode("utf-8")
     monkeypatch.setattr(requests, "get", p)
     yield p

--- a/tests/plugins/conftest.py
+++ b/tests/plugins/conftest.py
@@ -31,15 +31,15 @@ def is_uuid_valid(uuid_str: str) -> bool:
 @pytest.fixture
 def plugin_config():
     c = Config(schema=PlantUMLPlugin.config_scheme)
-    c['puml_url'] = BASE_PUML_URL
+    c["puml_url"] = BASE_PUML_URL
     return c
 
 
 @pytest.fixture
 def plugin_config_custom_keyword():
     c = Config(schema=PlantUMLPlugin.config_scheme)
-    c['puml_url'] = BASE_PUML_URL
-    c['puml_keyword'] = CUSTOM_PUML_KEYWORD
+    c["puml_url"] = BASE_PUML_URL
+    c["puml_keyword"] = CUSTOM_PUML_KEYWORD
     return c
 
 
@@ -53,7 +53,7 @@ def plugin_environment():
 def plant_uml_plugin(plugin_config):
     plugin = PlantUMLPlugin()
     c = Config(schema=plugin.config_scheme)
-    c['puml_url'] = BASE_PUML_URL
+    c["puml_url"] = BASE_PUML_URL
     plugin.config = c
     plugin.on_config(c)
 
@@ -64,8 +64,8 @@ def plant_uml_plugin(plugin_config):
 def plant_uml_plugin_custom_keyword(plugin_config_custom_keyword):
     plugin = PlantUMLPlugin()
     c = Config(schema=plugin.config_scheme)
-    c['puml_url'] = BASE_PUML_URL
-    c['puml_keyword'] = CUSTOM_PUML_KEYWORD
+    c["puml_url"] = BASE_PUML_URL
+    c["puml_keyword"] = CUSTOM_PUML_KEYWORD
     plugin.config = c
     plugin.on_config(c)
 
@@ -83,17 +83,16 @@ def diagrams_dict(diagram_and_encoded):
 
 @pytest.fixture(scope="package")
 def md_lines():
-    with open(TESTDATA_DIR.joinpath('markdown.md')) as f:
+    with open(TESTDATA_DIR.joinpath("markdown.md")) as f:
         return f.readlines()
 
 
 @pytest.fixture
 def html_page(plugin_environment, diagrams_dict):
-    page = MagicMock(title='Test, page', file=MagicMock(), config=MagicMock())
+    page = MagicMock(title="Test, page", file=MagicMock(), config=MagicMock())
     template = plugin_environment.get_template("output.html")
     page.content = template.render(
-        uuid_class=PlantUMLPlugin.pre_class_name,
-        uuids=diagrams_dict.keys()
+        uuid_class=PlantUMLPlugin.pre_class_name, uuids=diagrams_dict.keys()
     )
     page.html = page.content
     return page

--- a/tests/plugins/conftest.py
+++ b/tests/plugins/conftest.py
@@ -75,9 +75,9 @@ def plant_uml_plugin_custom_keyword(plugin_config_custom_keyword):
 @pytest.fixture
 def diagrams_dict(diagram_and_encoded):
     return {
-        str(uuid.uuid4()): diagram_and_encoded[0],
-        str(uuid.uuid4()): diagram_and_encoded[0],
-        str(uuid.uuid4()): diagram_and_encoded[0],
+        str(uuid.uuid4()): (diagram_and_encoded[0], None),
+        str(uuid.uuid4()): (diagram_and_encoded[0], None),
+        str(uuid.uuid4()): (diagram_and_encoded[0], None),
     }
 
 

--- a/tests/plugins/test_plugin.py
+++ b/tests/plugins/test_plugin.py
@@ -2,9 +2,13 @@ from mkdocs_puml.plugin import PlantUMLPlugin
 from mkdocs_puml.puml import PlantUML
 from tests.conftest import BASE_PUML_KEYWORD, BASE_PUML_URL, CUSTOM_PUML_KEYWORD
 from tests.plugins.conftest import is_uuid_valid
+import os
+import shutil
+import tempfile
 
 
 def test_on_config(plugin_config):
+    # Test if the plugin is correctly configured with default settings
     plugin = PlantUMLPlugin()
     plugin.config = plugin_config
 
@@ -18,6 +22,7 @@ def test_on_config(plugin_config):
 
 
 def test_on_config_custom_keyword(plugin_config_custom_keyword):
+    # Test if the plugin is correctly configured with a custom keyword
     plugin = PlantUMLPlugin()
     plugin.config = plugin_config_custom_keyword
 
@@ -31,6 +36,7 @@ def test_on_config_custom_keyword(plugin_config_custom_keyword):
 
 
 def test_on_page_markdown(plant_uml_plugin, md_lines):
+    # Test if PlantUML diagrams are correctly extracted from markdown
     plant_uml_plugin.on_page_markdown("\n".join(md_lines))
 
     assert len(plant_uml_plugin.diagrams) == 2
@@ -43,6 +49,7 @@ def test_on_page_markdown(plant_uml_plugin, md_lines):
 
 
 def test_on_page_markdown_custom_keyword(plant_uml_plugin_custom_keyword, md_lines):
+    # Test if PlantUML diagrams are correctly extracted with a custom keyword
     plant_uml_plugin_custom_keyword.on_page_markdown("\n".join(md_lines))
 
     assert len(plant_uml_plugin_custom_keyword.diagrams) == 1
@@ -55,6 +62,7 @@ def test_on_page_markdown_custom_keyword(plant_uml_plugin_custom_keyword, md_lin
 
 
 def test_on_env(mock_requests, plant_uml_plugin, diagrams_dict, plugin_environment):
+    # Test if PlantUML diagrams are correctly converted to SVG
     plant_uml_plugin.diagrams = diagrams_dict
     plant_uml_plugin.on_env(plugin_environment)
 
@@ -65,9 +73,14 @@ def test_on_env(mock_requests, plant_uml_plugin, diagrams_dict, plugin_environme
         assert light_svg.startswith('<svg')
         assert dark_svg is None  # Since auto_dark is False by default
 
-    # If you want to test the auto_dark feature, you can add another test:
+def test_on_env_auto_dark(mock_requests, plant_uml_plugin, diagrams_dict, plugin_environment):
+    # Test if PlantUML diagrams are correctly converted to both light and dark SVGs
     plant_uml_plugin.auto_dark = True
+    plant_uml_plugin.diagrams = diagrams_dict
+    mock_requests.reset_mock()
     plant_uml_plugin.on_env(plugin_environment)
+
+    assert mock_requests.call_count == 2 * len(diagrams_dict)
 
     for light_svg, dark_svg in plant_uml_plugin.diagrams.values():
         assert isinstance(light_svg, str)
@@ -77,7 +90,86 @@ def test_on_env(mock_requests, plant_uml_plugin, diagrams_dict, plugin_environme
 
 
 def test_on_post_page(plant_uml_plugin, diagrams_dict, html_page):
+    # Test if PlantUML diagrams are correctly inserted into the HTML output
     plant_uml_plugin.diagrams = diagrams_dict
     output = plant_uml_plugin.on_post_page(html_page.content, html_page)
 
     assert output.count(f'<div class="{plant_uml_plugin.div_class_name}">') == len(diagrams_dict)
+    assert '<script src="assets/javascripts/puml/dark.js"></script>' in output
+
+    # Test the case where page.html exists
+    html_page.html = html_page.content
+    output = plant_uml_plugin.on_post_page(html_page.content, html_page)
+    assert html_page.html.count(f'<div class="{plant_uml_plugin.div_class_name}">') == len(diagrams_dict)
+
+
+def test_on_post_page_without_html_attribute(plant_uml_plugin, diagrams_dict, html_page):
+    # Test if the plugin handles pages without the 'html' attribute correctly
+    plant_uml_plugin.diagrams = diagrams_dict
+    delattr(html_page, 'html')
+    output = plant_uml_plugin.on_post_page(html_page.content, html_page)
+
+    assert output.count(f'<div class="{plant_uml_plugin.div_class_name}">') == len(diagrams_dict)
+    assert '<script src="assets/javascripts/puml/dark.js"></script>' in output
+
+
+def test_on_post_page_with_existing_script(plant_uml_plugin, diagrams_dict, html_page):
+    # Test if the plugin doesn't duplicate the script tag when it already exists
+    plant_uml_plugin.diagrams = diagrams_dict
+    html_page.content += '<script src="assets/javascripts/puml/dark.js"></script>'
+    output = plant_uml_plugin.on_post_page(html_page.content, html_page)
+
+    assert output.count('<script src="assets/javascripts/puml/dark.js"></script>') == 1
+
+
+def test_on_post_build(tmp_path, plant_uml_plugin):
+    # Test if static files are correctly copied during the build process
+    config = {'site_dir': str(tmp_path)}
+    
+    dest_dir = os.path.join(tmp_path, 'assets', 'javascripts', 'puml')
+    if os.path.exists(dest_dir):
+        shutil.rmtree(dest_dir)
+    
+    plant_uml_plugin.on_post_build(config)
+    
+    assert os.path.exists(dest_dir)
+    static_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'mkdocs_puml', 'static')
+    for file_name in os.listdir(static_dir):
+        assert os.path.exists(os.path.join(dest_dir, file_name))
+
+    # Test when the directory already exists
+    plant_uml_plugin.on_post_build(config)
+    
+    for file_name in os.listdir(static_dir):
+        assert os.path.exists(os.path.join(dest_dir, file_name))
+
+
+def test_on_post_build_with_subdirectory(tmp_path, plant_uml_plugin):
+    # Test if the plugin correctly handles subdirectories in the static folder
+    config = {'site_dir': str(tmp_path)}
+    
+    static_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'mkdocs_puml', 'static')
+    with tempfile.TemporaryDirectory(dir=static_dir) as temp_subdir:
+        plant_uml_plugin.on_post_build(config)
+    
+    dest_dir = os.path.join(tmp_path, 'assets', 'javascripts', 'puml')
+    for item in os.listdir(dest_dir):
+        assert os.path.isfile(os.path.join(dest_dir, item))
+
+def test_replace_method(plant_uml_plugin):
+    # Test if the _replace method correctly handles both light and dark SVGs
+    key = "test_key"
+    content = f'<pre class="{plant_uml_plugin.pre_class_name}">{key}</pre>'
+    
+    # Test without dark SVG
+    plant_uml_plugin.diagrams[key] = ("<svg>light</svg>", None)
+    result = plant_uml_plugin._replace(key, content)
+    assert f'<div class="{plant_uml_plugin.div_class_name}"><svg>light</svg></div>' in result
+    
+    # Test with dark SVG
+    plant_uml_plugin.diagrams[key] = ("<svg>light</svg>", "<svg>dark</svg>")
+    result = plant_uml_plugin._replace(key, content)
+    assert 'data-puml-theme="light"' in result
+    assert 'data-puml-theme="dark"' in result
+    assert '<svg>light</svg>' in result
+    assert '<svg>dark</svg>' in result

--- a/tests/plugins/test_plugin.py
+++ b/tests/plugins/test_plugin.py
@@ -10,8 +10,10 @@ def test_on_config(plugin_config):
 
     plugin.on_config(plugin_config)
 
-    assert isinstance(plugin.puml, PlantUML)
-    assert plugin.puml.base_url == BASE_PUML_URL
+    assert isinstance(plugin.puml_light, PlantUML)
+    assert isinstance(plugin.puml_dark, PlantUML)
+    assert plugin.puml_light.base_url == BASE_PUML_URL + "svg/"
+    assert plugin.puml_dark.base_url == BASE_PUML_URL + "dsvg/"
     assert plugin.puml_keyword == BASE_PUML_KEYWORD
 
 
@@ -21,8 +23,10 @@ def test_on_config_custom_keyword(plugin_config_custom_keyword):
 
     plugin.on_config(plugin_config_custom_keyword)
 
-    assert isinstance(plugin.puml, PlantUML)
-    assert plugin.puml.base_url == BASE_PUML_URL
+    assert isinstance(plugin.puml_light, PlantUML)
+    assert isinstance(plugin.puml_dark, PlantUML)
+    assert plugin.puml_light.base_url == BASE_PUML_URL + "svg/"
+    assert plugin.puml_dark.base_url == BASE_PUML_URL + "dsvg/"
     assert plugin.puml_keyword == CUSTOM_PUML_KEYWORD
 
 
@@ -56,8 +60,20 @@ def test_on_env(mock_requests, plant_uml_plugin, diagrams_dict, plugin_environme
 
     assert mock_requests.call_count == len(diagrams_dict)
 
-    for v in diagrams_dict.values():
-        assert v.startswith('<svg')
+    for light_svg, dark_svg in plant_uml_plugin.diagrams.values():
+        assert isinstance(light_svg, str)
+        assert light_svg.startswith('<svg')
+        assert dark_svg is None  # Since auto_dark is False by default
+
+    # If you want to test the auto_dark feature, you can add another test:
+    plant_uml_plugin.auto_dark = True
+    plant_uml_plugin.on_env(plugin_environment)
+
+    for light_svg, dark_svg in plant_uml_plugin.diagrams.values():
+        assert isinstance(light_svg, str)
+        assert isinstance(dark_svg, str)
+        assert light_svg.startswith('<svg')
+        assert dark_svg.startswith('<svg')
 
 
 def test_on_post_page(plant_uml_plugin, diagrams_dict, html_page):

--- a/tests/plugins/test_plugin.py
+++ b/tests/plugins/test_plugin.py
@@ -4,7 +4,6 @@ from tests.conftest import BASE_PUML_KEYWORD, BASE_PUML_URL, CUSTOM_PUML_KEYWORD
 from tests.plugins.conftest import is_uuid_valid
 import os
 import shutil
-import tempfile
 
 
 def test_on_config(plugin_config):
@@ -70,8 +69,9 @@ def test_on_env(mock_requests, plant_uml_plugin, diagrams_dict, plugin_environme
 
     for light_svg, dark_svg in plant_uml_plugin.diagrams.values():
         assert isinstance(light_svg, str)
-        assert light_svg.startswith('<svg')
+        assert light_svg.startswith("<svg")
         assert dark_svg is None  # Since auto_dark is False by default
+
 
 def test_on_env_auto_dark(mock_requests, plant_uml_plugin, diagrams_dict, plugin_environment):
     # Test if PlantUML diagrams are correctly converted to both light and dark SVGs
@@ -85,8 +85,8 @@ def test_on_env_auto_dark(mock_requests, plant_uml_plugin, diagrams_dict, plugin
     for light_svg, dark_svg in plant_uml_plugin.diagrams.values():
         assert isinstance(light_svg, str)
         assert isinstance(dark_svg, str)
-        assert light_svg.startswith('<svg')
-        assert dark_svg.startswith('<svg')
+        assert light_svg.startswith("<svg")
+        assert dark_svg.startswith("<svg")
 
 
 def test_on_post_page(plant_uml_plugin, diagrams_dict, html_page):
@@ -100,13 +100,15 @@ def test_on_post_page(plant_uml_plugin, diagrams_dict, html_page):
     # Test the case where page.html exists
     html_page.html = html_page.content
     output = plant_uml_plugin.on_post_page(html_page.content, html_page)
-    assert html_page.html.count(f'<div class="{plant_uml_plugin.div_class_name}">') == len(diagrams_dict)
+    assert html_page.html.count(f'<div class="{plant_uml_plugin.div_class_name}">') == len(
+        diagrams_dict
+    )
 
 
 def test_on_post_page_without_html_attribute(plant_uml_plugin, diagrams_dict, html_page):
     # Test if the plugin handles pages without the 'html' attribute correctly
     plant_uml_plugin.diagrams = diagrams_dict
-    delattr(html_page, 'html')
+    delattr(html_page, "html")
     output = plant_uml_plugin.on_post_page(html_page.content, html_page)
 
     assert output.count(f'<div class="{plant_uml_plugin.div_class_name}">') == len(diagrams_dict)
@@ -124,52 +126,53 @@ def test_on_post_page_with_existing_script(plant_uml_plugin, diagrams_dict, html
 
 def test_on_post_build(tmp_path, plant_uml_plugin):
     # Test if static files are correctly copied during the build process
-    config = {'site_dir': str(tmp_path)}
-    
-    dest_dir = os.path.join(tmp_path, 'assets', 'javascripts', 'puml')
+    config = {"site_dir": str(tmp_path)}
+
+    dest_dir = os.path.join(tmp_path, "assets", "javascripts", "puml")
     if os.path.exists(dest_dir):
         shutil.rmtree(dest_dir)
-    
+
     plant_uml_plugin.on_post_build(config)
-    
+
     assert os.path.exists(dest_dir)
-    static_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'mkdocs_puml', 'static')
+    static_dir = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "mkdocs_puml", "static"
+    )
     for file_name in os.listdir(static_dir):
         assert os.path.exists(os.path.join(dest_dir, file_name))
 
     # Test when the directory already exists
     plant_uml_plugin.on_post_build(config)
-    
+
     for file_name in os.listdir(static_dir):
         assert os.path.exists(os.path.join(dest_dir, file_name))
 
 
 def test_on_post_build_with_subdirectory(tmp_path, plant_uml_plugin):
     # Test if the plugin correctly handles subdirectories in the static folder
-    config = {'site_dir': str(tmp_path)}
-    
-    static_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'mkdocs_puml', 'static')
-    with tempfile.TemporaryDirectory(dir=static_dir) as temp_subdir:
-        plant_uml_plugin.on_post_build(config)
-    
-    dest_dir = os.path.join(tmp_path, 'assets', 'javascripts', 'puml')
+    config = {"site_dir": str(tmp_path)}
+
+    plant_uml_plugin.on_post_build(config)
+
+    dest_dir = os.path.join(tmp_path, "assets", "javascripts", "puml")
     for item in os.listdir(dest_dir):
         assert os.path.isfile(os.path.join(dest_dir, item))
+
 
 def test_replace_method(plant_uml_plugin):
     # Test if the _replace method correctly handles both light and dark SVGs
     key = "test_key"
     content = f'<pre class="{plant_uml_plugin.pre_class_name}">{key}</pre>'
-    
+
     # Test without dark SVG
     plant_uml_plugin.diagrams[key] = ("<svg>light</svg>", None)
     result = plant_uml_plugin._replace(key, content)
     assert f'<div class="{plant_uml_plugin.div_class_name}"><svg>light</svg></div>' in result
-    
+
     # Test with dark SVG
     plant_uml_plugin.diagrams[key] = ("<svg>light</svg>", "<svg>dark</svg>")
     result = plant_uml_plugin._replace(key, content)
     assert 'data-puml-theme="light"' in result
     assert 'data-puml-theme="dark"' in result
-    assert '<svg>light</svg>' in result
-    assert '<svg>dark</svg>' in result
+    assert "<svg>light</svg>" in result
+    assert "<svg>dark</svg>" in result

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -1,7 +1,8 @@
 from mkdocs_puml.encoder import encode
 
 
-def test_encode(diagram_and_encoded: (str, str)):
+def test_encode(diagram_and_encoded: tuple[str, str]):
+    # Ensures the encoded output matches the expected result.
     diagram, expected = diagram_and_encoded
     encoded = encode(diagram)
 

--- a/tests/test_puml.py
+++ b/tests/test_puml.py
@@ -5,21 +5,28 @@ from tests.conftest import BASE_PUML_URL
 
 
 def test_url_with_slash():
+    # Verify base_url ends with slash when provided with trailing slash
     puml = PlantUML(BASE_PUML_URL)
     assert puml.base_url.endswith('/')
 
 
 def test_url_without_slash():
+    # Ensure base_url ends with slash when provided without trailing slash
     puml = PlantUML(BASE_PUML_URL[:-1])
     assert puml.base_url.endswith('/')
 
 
 def test_num_worker_less_or_equal_zero():
-    with pytest.raises(ValueError):
+    # Confirm ValueError raised for invalid num_workers
+    with pytest.raises(ValueError, match="`num_workers` argument should be bigger than 0."):
         PlantUML(BASE_PUML_URL, num_workers=0)
 
+    with pytest.raises(ValueError, match="`num_workers` argument should be bigger than 0."):
+        PlantUML(BASE_PUML_URL, num_workers=-1)
 
-def test_translate(diagram_and_encoded: (str, str), mock_requests):
+
+def test_translate(diagram_and_encoded: tuple[str, str], mock_requests):
+    # Verify translation of multiple diagrams to SVG
     diagram, encoded = diagram_and_encoded
 
     diagrams = [diagram] * 2

--- a/tests/test_puml.py
+++ b/tests/test_puml.py
@@ -7,13 +7,13 @@ from tests.conftest import BASE_PUML_URL
 def test_url_with_slash():
     # Verify base_url ends with slash when provided with trailing slash
     puml = PlantUML(BASE_PUML_URL)
-    assert puml.base_url.endswith('/')
+    assert puml.base_url.endswith("/")
 
 
 def test_url_without_slash():
     # Ensure base_url ends with slash when provided without trailing slash
     puml = PlantUML(BASE_PUML_URL[:-1])
-    assert puml.base_url.endswith('/')
+    assert puml.base_url.endswith("/")
 
 
 def test_num_worker_less_or_equal_zero():
@@ -34,7 +34,7 @@ def test_translate(diagram_and_encoded: tuple[str, str], mock_requests):
     puml = PlantUML(BASE_PUML_URL)
     resp = puml.translate(diagrams)
 
-    assert puml.base_url.endswith('/')
+    assert puml.base_url.endswith("/")
 
     assert len(resp) == 2
 


### PR DESCRIPTION
Added support for dark mode with the  `auto_dark` option to address #33 

When this option is set the module will generate a second copy of the diagram in dark mode using the `/dsvg` server option.

In order to dynamically switch the image choice the module include a javascript file (`mkdocs_puml/static/dark.js`).

I just submitted a similar [PR to the mkdocs_build_plantuml](https://github.com/quantorconsulting/mkdocs_build_plantuml/pull/40) but I have to say, it was a lot easier to do in this project :+1: 

Some things I would focus on when reviewing:

- dark.js
  I'm not a webdev by any means so it might need some love.

- `puml.py/_stylize_svg()`
   Now uses a css var lookup to set the background instead of fixing it to `#ffff`

## Example Output

Here's an example of the output - I used the 2 cards to show they system state and the user preference so it's easier to follow along with the transition. You can find the whole example in [my develop branch.](https://github.com/OnceUponALoop/mkdocs_puml/tree/develop/example)

> **Note:** Example include addition of the `skinparam backgroundColor transparent` directive to the  puml exmaple diagrams.


![output](https://github.com/user-attachments/assets/04314487-47ba-4309-bc6e-20856405395a)
