### PR TITLE
Set preserveAspectRatio to sensible default

### DIFF
--- a/mkdocs_puml/puml.py
+++ b/mkdocs_puml/puml.py
@@ -123,5 +123,5 @@ class PlantUML:
         Notes:
             It can be used to add support of light / dark theme.
         """
-        svg.setAttribute('preserveAspectRatio', "true")
+        svg.setAttribute('preserveAspectRatio', "xMidYMid meet")
         svg.setAttribute('style', 'background: #ffffff')


### PR DESCRIPTION
Updated the default `preserveAspectRatio` setting to a sensible default as `true` is not currently valid.