### PR TITLE
fix: Do not panic when puml server returns 404

### DIFF
--- a/mkdocs_puml/puml.py
+++ b/mkdocs_puml/puml.py
@@ -28,6 +28,7 @@ class PlantUML:
     """
 
     _html_comment_regex = re.compile(r"<!--.*?-->", flags=re.DOTALL)
+    ERROR_SVG = '<svg><text>Error</text></svg>'
 
     def __init__(
         self,
@@ -108,6 +109,9 @@ class PlantUML:
             SVG representation of the diagram
         """
         resp = requests.get(urljoin(self.base_url, encoded_diagram), verify=self.verify_ssl)
+
+        if not resp.ok:
+            return self.ERROR_SVG
 
         # Use 'ignore' to strip non-utf chars
         return resp.content.decode("utf-8", errors="ignore")

--- a/tests/plugins/test_plugin.py
+++ b/tests/plugins/test_plugin.py
@@ -151,3 +151,17 @@ def test_replace_method(plant_uml_plugin):
     result = plant_uml_plugin._replace(key, content)
     assert '<div class="puml light"><svg>light</svg></div>' in result
     assert '<div class="puml dark"><svg>dark</svg></div>' in result
+
+
+def test_unsupported_output(mock_requests, plant_uml_plugin, diagrams_dict, plugin_environment):
+    # All requests return an erroneous response
+    mock_requests.return_value.ok = False
+
+    # Try converting to SVG
+    plant_uml_plugin.auto_dark = True
+    plant_uml_plugin.diagrams = diagrams_dict
+    plant_uml_plugin.on_env(plugin_environment)
+
+    for diagram in plant_uml_plugin.diagrams.values():
+        for variant in diagram:
+            assert '<text>Error</text>' in variant


### PR DESCRIPTION
Addresses https://github.com/MikhailKravets/mkdocs_puml/issues/48

Instead of panicking with `list index out of range` the document is generated with a fallback minimal svg
