### PR TITLE
Supporting multiple output formats

### DIFF
--- a/mkdocs_puml/config.py
+++ b/mkdocs_puml/config.py
@@ -37,6 +37,16 @@ class InteractionConfig(Config):
     enabled = Type(bool, default=True)
 
 
+class OutputFormat(Enum):
+    PNG = "png"
+    SVG = "svg"
+    TXT = "txt"
+
+    @classmethod
+    def values(cls):
+        return [v.value for v in cls]
+
+
 class PlantUMLConfig(Config):
     puml_url = Type(str)
     puml_keyword = Type(str, default="puml")
@@ -46,3 +56,4 @@ class PlantUMLConfig(Config):
     theme = SubConfig(ThemeConfig)  # SubConfig already has an `{}` as default
     cache = SubConfig(CacheConfig)
     interaction = SubConfig(InteractionConfig)
+    output_format = Choice(OutputFormat.values(), default=OutputFormat.SVG.value)

--- a/mkdocs_puml/plugin.py
+++ b/mkdocs_puml/plugin.py
@@ -81,7 +81,8 @@ class PlantUMLPlugin(BasePlugin[PlantUMLConfig]):
         self.puml = PlantUML(
             self.config.puml_url,
             verify_ssl=self.config.verify_ssl,
-            timeout=self.config.request_timeout
+            timeout=self.config.request_timeout,
+            output_format=self.config.output_format
         )
         self.puml_keyword = self.config.puml_keyword
         self.regex = re.compile(rf"```{self.puml_keyword}(\n.+?)```", flags=re.DOTALL)

--- a/tests/plugins/test_plugin.py
+++ b/tests/plugins/test_plugin.py
@@ -30,6 +30,7 @@ def test_on_config(plugin_config):
     assert "assets/mkdocs_puml/interaction.js" in plugin_config["extra_javascript"]
 
     assert plugin.puml.timeout == plugin_config.request_timeout
+    assert plugin.config.output_format == 'svg'
 
 
 def test_on_config_theme_disabled(plugin_config):


### PR DESCRIPTION
The PlantUML class (and the plantuml server) supports various formats but it currently uses the `svg` format only.
With this change, the user can choose the output format using the `output_format` option in the configuration and selecting `svg` (default), `png` or `txt` (Ascii art)