### PR TITLE
Change hyperlink color in dark theme

### DIFF
--- a/themes/default/dark.puml
+++ b/themes/default/dark.puml
@@ -10,7 +10,7 @@ root {
   	LineThickness 1.0
   	Shadowing: 0.0;
 
-  	HyperLinkColor blue
+  	HyperLinkColor LightSkyBlue
   	FontColor white
   	LineColor #e7e7e7
   	BackGroundColor #313139


### PR DESCRIPTION
Dark theme need more contrast for links. Default blue is too dark.

Before
![image](https://github.com/user-attachments/assets/a76f69ea-c4b0-475c-80f1-70179475d950)


After:

![image](https://github.com/user-attachments/assets/eaa10926-4db0-4f5a-98ea-364c53fc0280)
