### PR TITLE
fix: Complex/large diagrams result in enormous whitespace frames

### DIFF
--- a/mkdocs_puml/static/puml.css
+++ b/mkdocs_puml/static/puml.css
@@ -43,8 +43,8 @@ body[data-md-color-scheme="slate"] .puml.dark {
 }
 
 .puml .diagram {
+    height: auto !important;
     width: 100% !important;
-    min-height: 300px !important;
 }
 
 .puml .diagram.wide-svg {


### PR DESCRIPTION
mkdocs_puml already contains special handling of wide diagrams, preventing overly large empty blocks framing the diagrams.

The same pattern appears for large/complex diagrams, even if their aspect ratio is high, not wide.