### PR TITLE
Support local plantuml binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ Bob -> Alice : hello
 
 That's it, `mkdocs_puml` will automatically build `SVG` diagrams from the code 🎉
 
+For a local plantuml, just provide the command to run instead. For example:
+
+```yaml
+plugins:
+  - plantuml:
+      puml_bin: plantuml
+```
+
 For more information, please refer to the [**documentation**](https://mikhailkravets.github.io/mkdocs_puml/).
 
 ## License

--- a/docs/docs/getting_started/setup.md
+++ b/docs/docs/getting_started/setup.md
@@ -7,7 +7,11 @@
     ```yaml
     plugins:
     - plantuml:
+        # For online service
         puml_url: https://www.plantuml.com/plantuml/
+        # Alternatively:
+        # puml_bin: /path/to/plantuml
+        # puml_args: [ '-timeout', '10', '-noerror', .... ]
         puml_keyword: puml
         request_timeout: 300
         verify_ssl: true
@@ -32,7 +36,10 @@ The communication of `mkdocs_puml` with PlantUML server can be configured with t
 
 ### `puml_url`
 
-`puml_url` is the only required parameter that expects a URL to PlantUML server.
+One of `puml_url` or `puml_cmdline` must be supplied. `puml_url` is only used if
+`pml_cmdline` is not supplied.
+
+`puml_url` expects a string URL to PlantUML server.
 The easiest solution is to set URL to [plantuml.com/plantuml](https://www.plantuml.com/plantuml/) such as
 
 ```yaml
@@ -45,7 +52,44 @@ However, this approach has its disadvantages. First of all, you may not want to 
 with the public server. Also, the public server has a rate limits, which can result in 509 errors.
 
 As mentioned in [Installation](index.md#installation) section, you may setup PlantUML server locally
-using Docker.
+using Docker, or you can use `puml_bin` to run `plantuml` locally.
+
+### `puml_cmdline`
+
+One of `puml_url` or `puml_cmdline` must be supplied. If `puml_mdline` is supplied,
+it is used in preference to `puml_url`.
+
+`puml_cmdline` expects a list of strings, forming a command to run `plantuml`.
+Typically, where `plantuml` is installed system-wide or the `plantuml` script
+is in your path, this can just be set to `[ 'plantuml' ]`.
+
+```yaml
+plugins:
+  - plantuml:
+      puml_cmdline: ['plantuml']
+```
+
+If no such script exists, you can execute java directly, for example:
+
+```yaml
+plugins:
+  - plantuml:
+      puml_cmdline:
+        - "java"
+        - "-jar"
+        - "/path/to/plantuml.jar"
+```
+
+Additional command line arguments can also be supplied to `plantuml`:
+
+```yaml
+plugins:
+  - plantuml:
+      puml_cmdline: 
+        - 'plantuml'
+        - '-graphvizdot'
+        - /path/to/dot
+```
 
 ### `puml_keyword`
 

--- a/mkdocs_puml/config.py
+++ b/mkdocs_puml/config.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from mkdocs.config.base import Config
-from mkdocs.config.config_options import Type, SubConfig, Choice
+from mkdocs.config.config_options import Type, SubConfig, Choice, ListOfItems
 
 
 class CacheBackend(Enum):
@@ -38,7 +38,8 @@ class InteractionConfig(Config):
 
 
 class PlantUMLConfig(Config):
-    puml_url = Type(str)
+    puml_url = Type(str, default="")
+    puml_cmdline = ListOfItems(Type(str), default=[])
     puml_keyword = Type(str, default="puml")
     verify_ssl = Type(bool, default=True)
     verbose = Type(bool, default=True)

--- a/mkdocs_puml/plugin.py
+++ b/mkdocs_puml/plugin.py
@@ -12,7 +12,7 @@ from mkdocs.plugins import BasePlugin
 from mkdocs_puml.config import PlantUMLConfig
 from mkdocs_puml.model import Count, Diagram, ThemeMode
 from mkdocs_puml.storage import AbstractStorage, build_storage
-from mkdocs_puml.puml import Fallback, PlantUML
+from mkdocs_puml.puml import Fallback, PlantUML, RemotePlantUML, LocalPlantUML
 from mkdocs_puml.theme import Theme
 
 
@@ -78,11 +78,15 @@ class PlantUMLPlugin(BasePlugin[PlantUMLConfig]):
             )
 
         self.console = Console(quiet=not self.config.verbose)
-        self.puml = PlantUML(
-            self.config.puml_url,
-            verify_ssl=self.config.verify_ssl,
-            timeout=self.config.request_timeout
-        )
+        if self.config.puml_cmdline:
+            self.puml = LocalPlantUML(self.config.puml_cmdline)
+        else:
+            self.puml = RemotePlantUML(
+                self.config.puml_url,
+                verify_ssl=self.config.verify_ssl,
+                timeout=self.config.request_timeout
+            )
+
         self.puml_keyword = self.config.puml_keyword
         self.regex = re.compile(rf"```{self.puml_keyword}(\n.+?)```", flags=re.DOTALL)
 

--- a/mkdocs_puml/puml.py
+++ b/mkdocs_puml/puml.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 import logging
 import typing
 import re
+import abc
 
 from urllib.parse import urljoin
 from xml.dom.minidom import Element, parseString  # nosec
@@ -28,6 +29,50 @@ class Fallback:
 
 
 class PlantUML:
+    @abc.abstractmethod
+    def translate(self, schemes: typing.Iterable[str]) -> typing.List[typing.Union[str, Fallback]]:
+        pass
+
+
+class LocalPlantUML(PlantUML):
+    def __init__(self, puml_cmdline: typing.List[str], output_format: str = "svg"):
+        self.puml_cmdline = puml_cmdline
+        self.output_format = output_format
+
+    def translate(self, schemes: typing.Iterable[str]) -> typing.List[typing.Union[str, Fallback]]:
+        return asyncio.run(self._translate(schemes))
+
+    async def _translate(self, schemes: typing.Iterable[str]) -> typing.List[typing.Union[str, Fallback]]:
+        tasks = [
+            self._generate(scheme) for scheme in schemes
+        ]
+        return await asyncio.gather(*tasks)
+
+    async def _generate(self, plantuml_code):
+        plantuml_code = plantuml_code.encode('utf8')
+        cmdline = self.puml_cmdline + [
+            '-p',
+            '-t' + self.output_format,
+            '-charset', 'UTF-8'
+        ]
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmdline,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE)
+            out, err = await proc.communicate(input=plantuml_code)
+        except Exception as exc:
+            return Fallback(status_code=500, message=str(exc))
+        else:
+            if proc.returncode != 0:
+                # plantuml returns a nice image in case of syntax error so log but still return out
+                logger.error(f'[puml] Error in PlantUML: {err.decode("utf-8")}')
+
+            return out.decode('utf-8')
+
+
+class RemotePlantUML(PlantUML):
     """PlantUML converter class.
     It requests PUML service, updates received `svg`
     and returns it to the user.

--- a/tests/test_puml.py
+++ b/tests/test_puml.py
@@ -1,16 +1,16 @@
-from mkdocs_puml.puml import Fallback, PlantUML
+from mkdocs_puml.puml import Fallback, RemotePlantUML
 from tests.conftest import BASE_PUML_URL
 
 
 def test_url_with_slash():
     # Verify base_url ends with slash when provided with trailing slash
-    puml = PlantUML(BASE_PUML_URL)
+    puml = RemotePlantUML(BASE_PUML_URL)
     assert puml.base_url.endswith("/")
 
 
 def test_url_without_slash():
     # Ensure base_url ends with slash when provided without trailing slash
-    puml = PlantUML(BASE_PUML_URL[:-1])
+    puml = RemotePlantUML(BASE_PUML_URL[:-1])
     assert puml.base_url.endswith("/")
 
 
@@ -22,7 +22,7 @@ def test_translate(diagram_and_encoded: tuple[str, str], mock_requests):
 
     mock_requests(len(diagrams))
 
-    puml = PlantUML(BASE_PUML_URL)
+    puml = RemotePlantUML(BASE_PUML_URL)
     resp = puml.translate(diagrams)
 
     assert puml.base_url == f"{BASE_PUML_URL}svg/"
@@ -43,7 +43,7 @@ def test_translate_fallback(diagram_and_encoded: tuple[str, str], mock_requests_
 
     mock_requests_fallback(len(diagrams))
 
-    puml = PlantUML(BASE_PUML_URL)
+    puml = RemotePlantUML(BASE_PUML_URL)
     resp = puml.translate(diagrams)
 
     assert len(resp) == 2


### PR DESCRIPTION
Fixes #50 

This is just a very quick implementation, shariing in the hope that it's useful to people tracking #50. I have  need to run plantuml locally without the hassle of spinning up a server using docker. It looked easy to run `plantuml` directly, so I made this quick change.

There are some drawbacks to this:

1) it could better use `asyncio` and do the generations concurrently (switch to `asyncio.create_subprocess_shell` etc.)
2) the configuration is a little quirky in that it picks one of the two options if both supplied.
3) I didn't think too hard about error handling

disclaimer: I was "inspired" by https://github.com/mikitex70/plantuml-markdown/blob/master/plantuml_markdown/plantuml_markdown.py#L497