### PR TITLE
feat: system certificate store option for verify_ssl

### DIFF
--- a/docs/docs/getting_started/setup.md
+++ b/docs/docs/getting_started/setup.md
@@ -11,7 +11,6 @@
         puml_keyword: puml
         request_timeout: 300
         verify_ssl: true
-        use_system_certificates: true
         verbose: true
         theme:
           enabled: true
@@ -79,45 +78,40 @@ plugins:
 
 ### `verify_ssl`
 
-In some cases, when using a custom PlantUML server setup, you may want to disable
-SSL verification. This can be achieved by
+By default `verify_ssl` is set to `true`, which enables SSL certificate validation using the [certifi](https://pypi.org/project/certifi/) CA bundle.
 
+In certain scenarios - such as when using a custom PlantUML server with self-signed certificates or operating in a corporate environment with TLS inspection — you may need to either use the system's trusted certificate store or disable SSL certificate verification entirely.
+This behavior can be configured using the `verify_ssl` option in your mkdocs.yml file.
+
+Using the system certificate store:  
+```yaml
+plugins:
+  - plantuml:
+      verify_ssl: "system"
+```
+
+Disabling SSL verification:  
 ```yaml
 plugins:
   - plantuml:
       verify_ssl: false
 ```
 
-By default `verify_ssl` is set to `true`.
+!!! warning "Security risk"
+    
+    Disabling SSL verification (`verify_ssl: false`) reduces security and should only be used in trusted, controlled environments.
 
 ???+ tip "Use self-signed SSL"
 
     Under the hood, `mkdocs_puml` uses [HTTPX](https://www.python-httpx.org/) to request PlantUML server.
-    If you're running the server with self-signed certificates you need to set `SSL_CERT_FILE` or
-    `SSL_CERT_DIR` environment variables before running `mkdocs`.
+    If you're running the server with self-signed certificates that are not contained in your system's
+    trusted certificate store you need to set `SSL_CERT_FILE` or `SSL_CERT_DIR` environment variables
+    before running `mkdocs`.
 
     For additional information refer to `HTTPX` documentation
 
     - [HTTPX - SSL](https://www.python-httpx.org/advanced/ssl/#making-https-requests-to-a-local-server).
     - [HTTPX - Environment Variables](https://www.python-httpx.org/environment_variables/#ssl_cert_dir).
-
-### `use_system_certificates`
-
-This parameter allows `mkdocs_puml` to use the system certificate store for SSL verification.  
-By default `use_system_certificates` is set to `true`.
-
-???+ info "verify_ssl takes precedence"
-
-    The `verify_ssl` parameter takes precedence over `use_system_certificates`. If `verify_ssl` is set to `false`, 
-system certificates will not be used regardless of the `use_system_certificates` setting.
-
-To disable system certificate usage (and use `certifi`'s CA bundle instead or use a specific CA bundle with `SSL_CERT_FILE` or `SSL_CERT_DIR` environment variable):
-
-```yaml
-plugins:
-  - plantuml:
-      use_system_certificates: false
-```
 
 ### `verbose`
 

--- a/docs/docs/getting_started/setup.md
+++ b/docs/docs/getting_started/setup.md
@@ -87,7 +87,7 @@ Using the system certificate store:
 ```yaml
 plugins:
   - plantuml:
-      verify_ssl: "system"
+      verify_ssl: system
 ```
 
 Disabling SSL verification:  

--- a/docs/docs/getting_started/setup.md
+++ b/docs/docs/getting_started/setup.md
@@ -11,6 +11,7 @@
         puml_keyword: puml
         request_timeout: 300
         verify_ssl: true
+        use_system_certificates: true
         verbose: true
         theme:
           enabled: true
@@ -99,6 +100,24 @@ By default `verify_ssl` is set to `true`.
 
     - [HTTPX - SSL](https://www.python-httpx.org/advanced/ssl/#making-https-requests-to-a-local-server).
     - [HTTPX - Environment Variables](https://www.python-httpx.org/environment_variables/#ssl_cert_dir).
+
+### `use_system_certificates`
+
+This parameter allows `mkdocs_puml` to use the system certificate store for SSL verification.  
+By default `use_system_certificates` is set to `true`.
+
+???+ info "verify_ssl takes precedence"
+
+    The `verify_ssl` parameter takes precedence over `use_system_certificates`. If `verify_ssl` is set to `false`, 
+system certificates will not be used regardless of the `use_system_certificates` setting.
+
+To disable system certificate usage (and use `certifi`'s CA bundle instead or use a specific CA bundle with `SSL_CERT_FILE` or `SSL_CERT_DIR` environment variable):
+
+```yaml
+plugins:
+  - plantuml:
+      use_system_certificates: false
+```
 
 ### `verbose`
 

--- a/mkdocs_puml/config.py
+++ b/mkdocs_puml/config.py
@@ -40,8 +40,7 @@ class InteractionConfig(Config):
 class PlantUMLConfig(Config):
     puml_url = Type(str)
     puml_keyword = Type(str, default="puml")
-    verify_ssl = Type(bool, default=True)
-    use_system_certificates = Type(bool, default=True)
+    verify_ssl = Choice([True, False, "system"], default=True)
     verbose = Type(bool, default=True)
     request_timeout = Type(int, default=300)
     theme = SubConfig(ThemeConfig)  # SubConfig already has an `{}` as default

--- a/mkdocs_puml/config.py
+++ b/mkdocs_puml/config.py
@@ -41,6 +41,7 @@ class PlantUMLConfig(Config):
     puml_url = Type(str)
     puml_keyword = Type(str, default="puml")
     verify_ssl = Type(bool, default=True)
+    use_system_certificates = Type(bool, default=True)
     verbose = Type(bool, default=True)
     request_timeout = Type(int, default=300)
     theme = SubConfig(ThemeConfig)  # SubConfig already has an `{}` as default

--- a/mkdocs_puml/plugin.py
+++ b/mkdocs_puml/plugin.py
@@ -81,6 +81,7 @@ class PlantUMLPlugin(BasePlugin[PlantUMLConfig]):
         self.puml = PlantUML(
             self.config.puml_url,
             verify_ssl=self.config.verify_ssl,
+            use_system_certificates=self.config.use_system_certificates,
             timeout=self.config.request_timeout
         )
         self.puml_keyword = self.config.puml_keyword

--- a/mkdocs_puml/plugin.py
+++ b/mkdocs_puml/plugin.py
@@ -81,7 +81,6 @@ class PlantUMLPlugin(BasePlugin[PlantUMLConfig]):
         self.puml = PlantUML(
             self.config.puml_url,
             verify_ssl=self.config.verify_ssl,
-            use_system_certificates=self.config.use_system_certificates,
             timeout=self.config.request_timeout
         )
         self.puml_keyword = self.config.puml_keyword

--- a/mkdocs_puml/puml.py
+++ b/mkdocs_puml/puml.py
@@ -36,8 +36,7 @@ class PlantUML:
     Attributes:
         base_url (str): Base URL to the PUML service
         num_workers (int): The size of pool to run requests in
-        verify_ssl (bool): Designates whether the ``requests`` should verify SSL certiticate
-        use_system_certificates (bool): Designates whether the ``requests`` should use system certificates
+        verify_ssl (bool|"system"): Designates whether the ``requests`` should verify SSL certiticate or use system certificates
         output_format (str): The output format for the diagrams (e.g., "svg" or "dsvg")
 
     Examples:
@@ -52,8 +51,7 @@ class PlantUML:
     def __init__(
         self,
         base_url: str,
-        verify_ssl: bool = True,
-        use_system_certificates: bool = True,
+        verify_ssl: bool|typing.Literal["system"] = True,
         output_format: str = "svg",
         timeout: int = 40,
     ):
@@ -62,15 +60,12 @@ class PlantUML:
         self.base_url = sanitize_url(base_url)
         self.base_url = f"{self.base_url}{output_format}/"
 
-        self.timeout = timeout
-        
-        if not verify_ssl:
-            self.verify = False
-        elif use_system_certificates:
+        if verify_ssl == "system":
             self.verify = ssl.create_default_context()
             self.verify.load_default_certs()
         else:
-            self.verify = True
+            self.verify = verify_ssl
+        self.timeout = timeout
 
     def translate(self, schemes: typing.Iterable[str]) -> typing.List[typing.Union[str, Fallback]]:
         """Translate PlantUML schemes into the received SVG image.
@@ -158,7 +153,7 @@ class PlantUML:
 
         Returns:
             Response: response from PlantUML server
-        """            
+        """
         async with AsyncClient(verify=self.verify, timeout=self.timeout) as client:
             return await client.get(uri)
 

--- a/mkdocs_puml/puml.py
+++ b/mkdocs_puml/puml.py
@@ -51,7 +51,7 @@ class PlantUML:
     def __init__(
         self,
         base_url: str,
-        verify_ssl: bool|typing.Literal["system"] = True,
+        verify_ssl: typing.Union[bool, typing.Literal["system"]] = True,
         output_format: str = "svg",
         timeout: int = 40,
     ):

--- a/mkdocs_puml/puml.py
+++ b/mkdocs_puml/puml.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 import logging
 import typing
 import re
+import ssl
 
 from urllib.parse import urljoin
 from xml.dom.minidom import Element, parseString  # nosec
@@ -36,6 +37,7 @@ class PlantUML:
         base_url (str): Base URL to the PUML service
         num_workers (int): The size of pool to run requests in
         verify_ssl (bool): Designates whether the ``requests`` should verify SSL certiticate
+        use_system_certificates (bool): Designates whether the ``requests`` should use system certificates
         output_format (str): The output format for the diagrams (e.g., "svg" or "dsvg")
 
     Examples:
@@ -51,6 +53,7 @@ class PlantUML:
         self,
         base_url: str,
         verify_ssl: bool = True,
+        use_system_certificates: bool = True,
         output_format: str = "svg",
         timeout: int = 40,
     ):
@@ -59,8 +62,15 @@ class PlantUML:
         self.base_url = sanitize_url(base_url)
         self.base_url = f"{self.base_url}{output_format}/"
 
-        self.verify_ssl = verify_ssl
         self.timeout = timeout
+        
+        if not verify_ssl:
+            self.verify = False
+        elif use_system_certificates:
+            self.verify = ssl.create_default_context()
+            self.verify.load_default_certs()
+        else:
+            self.verify = True
 
     def translate(self, schemes: typing.Iterable[str]) -> typing.List[typing.Union[str, Fallback]]:
         """Translate PlantUML schemes into the received SVG image.
@@ -141,15 +151,15 @@ class PlantUML:
         return svgs
 
     async def _request_one(self, uri: str) -> Response:
-        """Request request PlantUML server asynchronously
+        """Request PlantUML server asynchronously
 
         Args:
             uri (str): URI with encoded diagram attached to it
 
         Returns:
             Response: response from PlantUML server
-        """
-        async with AsyncClient(verify=self.verify_ssl, timeout=self.timeout) as client:
+        """            
+        async with AsyncClient(verify=self.verify, timeout=self.timeout) as client:
             return await client.get(uri)
 
     async def _request_all(self, schemes: list[str]):

--- a/tests/test_puml.py
+++ b/tests/test_puml.py
@@ -1,3 +1,5 @@
+import ssl
+from unittest.mock import patch, MagicMock
 from mkdocs_puml.puml import Fallback, PlantUML
 from tests.conftest import BASE_PUML_URL
 
@@ -12,6 +14,52 @@ def test_url_without_slash():
     # Ensure base_url ends with slash when provided without trailing slash
     puml = PlantUML(BASE_PUML_URL[:-1])
     assert puml.base_url.endswith("/")
+
+
+def test_use_system_certificates():
+    # Test all scenarios for use_system_certificates and verify_ssl parameters
+    
+    # Scenario 1: When use_system_certificates=True and verify_ssl=True, verify should be an SSL context
+    with patch('ssl.create_default_context') as mock_create_context:
+        mock_context = MagicMock()
+        mock_create_context.return_value = mock_context
+        
+        puml = PlantUML(BASE_PUML_URL, verify_ssl=True, use_system_certificates=True)
+        
+        mock_create_context.assert_called_once()
+        mock_context.load_default_certs.assert_called_once()
+        assert puml.verify == mock_context
+    
+    # Scenario 2: When use_system_certificates=False and verify_ssl=True, verify should be True
+    puml = PlantUML(BASE_PUML_URL, verify_ssl=True, use_system_certificates=False)
+    assert puml.verify is True
+    
+    # Scenario 3: When use_system_certificates=True and verify_ssl=False, verify should be False
+    with patch('ssl.create_default_context') as mock_create_context:
+        mock_context = MagicMock()
+        mock_create_context.return_value = mock_context
+        
+        puml = PlantUML(BASE_PUML_URL, verify_ssl=False, use_system_certificates=True)
+        
+        # SSL context should NOT be created when verify_ssl is False
+        mock_create_context.assert_not_called()
+        mock_context.load_default_certs.assert_not_called()
+        assert puml.verify is False
+    
+    # Scenario 4: When use_system_certificates=False and verify_ssl=False, verify should be False
+    puml = PlantUML(BASE_PUML_URL, verify_ssl=False, use_system_certificates=False)
+    assert puml.verify is False
+    
+    # Scenario 5: When no arguments are given (default values), verify should be an SSL context
+    with patch('ssl.create_default_context') as mock_create_context:
+        mock_context = MagicMock()
+        mock_create_context.return_value = mock_context
+        
+        puml = PlantUML(BASE_PUML_URL)  # No parameters specified, should use default True for both
+        
+        mock_create_context.assert_called_once()
+        mock_context.load_default_certs.assert_called_once()
+        assert puml.verify == mock_context
 
 
 def test_translate(diagram_and_encoded: tuple[str, str], mock_requests):

--- a/tests/test_puml.py
+++ b/tests/test_puml.py
@@ -1,4 +1,3 @@
-import ssl
 from unittest.mock import patch, MagicMock
 from mkdocs_puml.puml import Fallback, PlantUML
 from tests.conftest import BASE_PUML_URL
@@ -16,46 +15,25 @@ def test_url_without_slash():
     assert puml.base_url.endswith("/")
 
 
-def test_use_system_certificates():
-    # Test all scenarios for use_system_certificates and verify_ssl parameters
-    
-    # Scenario 1: When use_system_certificates=True and verify_ssl=True, verify should be an SSL context
-    with patch('ssl.create_default_context') as mock_create_context:
-        mock_context = MagicMock()
-        mock_create_context.return_value = mock_context
-        
-        puml = PlantUML(BASE_PUML_URL, verify_ssl=True, use_system_certificates=True)
-        
-        mock_create_context.assert_called_once()
-        mock_context.load_default_certs.assert_called_once()
-        assert puml.verify == mock_context
-    
-    # Scenario 2: When use_system_certificates=False and verify_ssl=True, verify should be True
-    puml = PlantUML(BASE_PUML_URL, verify_ssl=True, use_system_certificates=False)
+def test_verify_ssl_default_enabled():
+    # Verify SSL verification is enabled by default (using certifi CA bundle)
+    puml = PlantUML(BASE_PUML_URL)
     assert puml.verify is True
-    
-    # Scenario 3: When use_system_certificates=True and verify_ssl=False, verify should be False
-    with patch('ssl.create_default_context') as mock_create_context:
-        mock_context = MagicMock()
-        mock_create_context.return_value = mock_context
-        
-        puml = PlantUML(BASE_PUML_URL, verify_ssl=False, use_system_certificates=True)
-        
-        # SSL context should NOT be created when verify_ssl is False
-        mock_create_context.assert_not_called()
-        mock_context.load_default_certs.assert_not_called()
-        assert puml.verify is False
-    
-    # Scenario 4: When use_system_certificates=False and verify_ssl=False, verify should be False
-    puml = PlantUML(BASE_PUML_URL, verify_ssl=False, use_system_certificates=False)
+
+
+def test_verify_ssl_disabled():
+    # Verify SSL verification is disabled when set to false
+    puml = PlantUML(BASE_PUML_URL, verify_ssl=False)
     assert puml.verify is False
-    
-    # Scenario 5: When no arguments are given (default values), verify should be an SSL context
+
+
+def test_verify_ssl_system_certificates():
+    # When verify_ssl is set to "system", verify should be an SSL context
     with patch('ssl.create_default_context') as mock_create_context:
         mock_context = MagicMock()
         mock_create_context.return_value = mock_context
         
-        puml = PlantUML(BASE_PUML_URL)  # No parameters specified, should use default True for both
+        puml = PlantUML(BASE_PUML_URL, verify_ssl="system")
         
         mock_create_context.assert_called_once()
         mock_context.load_default_certs.assert_called_once()


### PR DESCRIPTION
Resolves #93

## Changes

- adds a new config `use_system_certificates`, which defaults to true
- `verify_ssl` takes precedence -> if `verify_ssl` is false, system certificates are not used, regardless of its config value

## Tests

I let the Cursor AI add tests for this new feature, because I was too lazy and I'm not very familiar with pytests..
What do you think?