### PR TITLE
chore: drop python 3.9 support and add python 3.14 to CI workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
     outputs:
       coverage: ${{ steps.test.outputs.coverage }}
 

--- a/pyproject-old.toml
+++ b/pyproject-old.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = {file = "LICENSE"}
 classifiers = ["License :: OSI Approved :: MIT License"]
 dynamic = ["version", "description"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "httpx >= 0.27",
     "markdown >= 3.2.1, < 4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 plantuml = "mkdocs_puml.plugin:PlantUMLPlugin"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 httpx = "^0.27"
 markdown = "^3.2"
 mkdocs = "^1.4"


### PR DESCRIPTION
- dropped support for python 3.9 because it is end-of-life: https://devguide.python.org/versions
- added python 3.14 to the CI workflow so that it is covered in the tests